### PR TITLE
chore: update Minecraft to 26.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ archives_base_name=Armor_Hud
 # check this on https://modmuss50.me/fabric.html or https://fabricmc.net/develop
 fabric_version=0.152.2+26.2
 # ModMenu Version can be found on this modrinth page: https://modrinth.com/mod/modmenu/versions?l=fabric
-modmenu_version=1.10.5
+modmenu_version=20.0.0-alpha.1
 # Cloth Config Version can be found on this modrinth page: https://modrinth.com/mod/cloth-config/versions?l=fabric
 cloth_config_version=26.2.155
 mappings_channel=none


### PR DESCRIPTION
Automated Jenkins update run for Armor HUD.

- Minecraft: 26.2 -> 26.2
- Mod version: 3.4-26.2 -> 3.4-26.2
- Loader: 0.19.3
- Fabric API: 0.152.2+26.2
- Mod Menu: 20.0.0-alpha.1
- Cloth Config: 26.2.155
- Mappings channel: none
- Yarn mappings: n/a

Build: https://ci.saolghra.co.uk/job/Armor-Hud/51/